### PR TITLE
Change the name of the defined function for non-esm (sprockets) build

### DIFF
--- a/app/assets/javascripts/blacklight_oembed/oembed.js
+++ b/app/assets/javascripts/blacklight_oembed/oembed.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.BlacklightOembed = factory());
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.oembed = factory());
 })(this, (function () { 'use strict';
 
   function oEmbed(elements) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,7 @@ const rollupConfig = {
     file: `app/assets/javascripts/blacklight_oembed/${fileDest}.js`,
     format: ESM ? 'es' : 'umd',
     generatedCode: { preset: 'es2015' },
-    name: ESM ? undefined : 'BlacklightOembed'
+    name: ESM ? undefined : 'oembed'
   },
   plugins: [includePaths(includePathOptions)]
 }


### PR DESCRIPTION
This will allow the oembed function name to match the name used by the module import