### PR TITLE
Check that the manifest file exists

### DIFF
--- a/lib/generators/blacklight_oembed/install_generator.rb
+++ b/lib/generators/blacklight_oembed/install_generator.rb
@@ -19,6 +19,8 @@ module BlacklightOembed
     end
 
     def appease_sprockets4
+      return unless File.exist?('app/assets/config/manifest.js')
+
       append_to_file 'app/assets/config/manifest.js', "\n//= link blacklight-oembed/oembed.js"
     end
 


### PR DESCRIPTION
Stops the install generator from giving up after a failure (file doesn't exist in Rails 8)